### PR TITLE
refactor(package.json): normalize git repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PolymeshAssociation/signing-manager-types.git"
+    "url": "git+https://github.com/PolymeshAssociation/signing-manager-types.git"
   }
 }


### PR DESCRIPTION
### Description

normalize git repo url in package.json

This resolves the warnings from the CI pipeline

```
'npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.\n' +
    'npm WARN publish errors corrected:\n' +
    'npm WARN publish "repository.url" was normalized to "git+https://github.com/PolymeshAssociation/signing-manager-types.git"\n' 
```

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
