### PR TITLE
ci: update release token to use SMT-specific one

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ASSOCIATION_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.SMT_NPM_RELEASE_TOKEN }}
         run: |
           cd dist
           yarn --frozen-lockfile


### PR DESCRIPTION
### Description

Updates the NPM token secret reference in the GitHub Actions release workflow from `ASSOCIATION_NPM_TOKEN` to `SMT_NPM_RELEASE_TOKEN`. This change ensures the signing-manager-types package uses its dedicated NPM token for releases rather than a generic association token, providing better security isolation and token management for this specific project.

### Breaking Changes

None. This is a configuration change that doesn't affect the package functionality or API.

### JIRA Link

NA

### Checklist

- [] Updated the Readme.md (if required) ? NA
