### PR TITLE
feat: add Ethereum signing manager types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ This defines the types needed to implement a [Polymesh SDK](https://github.com/P
 
 A signing manager abstracts the cryptographic signing of transactions so the SDK is indifferent to where and how private keys are stored.
 
+### Ethereum signing managers
+
+Polymesh's `revive` pallet lets an Ethereum key dispatch any runtime call, as the account `AccountId32 = <20 byte H160> ++ [0xEE; 12]`. A signing manager holding Ethereum keys implements `EthSigningManager`, which extends `SigningManager` with a single synchronous `getEthSigner()` method. The SDK routes on the signing address, so this capability is additive — existing signing managers are unaffected, and a hybrid manager may hold both native and Ethereum keys.
+
+- `EthTransactionRequest` — the Ethereum transaction the SDK builds. Every field is supplied by the SDK, including the gas limit and the chain ID; a signer must not estimate gas, substitute its own values, or sign for whichever chain the provider happens to be connected to
+- `EthSigner` — implements `signTransaction` (returns raw signed bytes for the SDK to broadcast — preferred) and/or `sendTransaction` (the wallet broadcasts and returns the Ethereum transaction hash). At least one is required, and the SDK decides which to use from whichever is present rather than from a flag
+- `EthSignerCapabilities` — what cannot be derived from the signer's shape. Currently just `eip1559`, which defaults to `true` and is set to `false` by signers that can only encode legacy (type 0) transactions
+- `isEthSigningManager(manager)` — typeguard for consumers routing between the native and Ethereum paths
+
+A user rejecting the request should surface as an error carrying the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) code `4001`; the SDK maps that to `TransactionRejectedByUser`. Re-throwing the provider's own error, or preserving its `code` when wrapping it, is usually enough.
+
+An `EthSigningManager` still implements the whole `SigningManager` interface: `getAccounts()` returns the SS58 encoded `0xEE` accounts (not H160 hex), `setSs58Format()` is honoured when encoding them, and `getExternalSigner()` returns a `PolkadotSigner` whose `signPayload` and `signRaw` throw — an Ethereum key cannot produce a signature the chain will accept over a SCALE payload.
+
 ### Implementations
 - [Browser](https://github.com/PolymeshAssociation/browser-extension-signing-manager) Private keys are saved in a browser extension
 - [WalletConnect](https://github.com/PolymeshAssociation/walletconnect-signing-manager) Formerly WalletConnect adaptor (rebranded to Reown)

--- a/src/__tests__/eth-signer.ts
+++ b/src/__tests__/eth-signer.ts
@@ -1,0 +1,201 @@
+import {
+  EthSigner,
+  EthSignerCapabilities,
+  EthSigningManager,
+  EthTransactionRequest,
+  isEthSigningManager,
+  PolkadotSigner,
+  SigningManager,
+} from '../index';
+
+const externalSigner = {
+  signPayload: () => {
+    throw new Error('Ethereum keys cannot sign SCALE payloads');
+  },
+  signRaw: () => {
+    throw new Error('Ethereum keys cannot sign raw payloads');
+  },
+} as unknown as PolkadotSigner;
+
+const nativeManager: SigningManager = {
+  getAccounts: async () => ['5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'],
+  getExternalSigner: () => externalSigner,
+  setSs58Format: () => undefined,
+};
+
+const capabilities: EthSignerCapabilities = { eip1559: true };
+
+const ethSigner: EthSigner = {
+  capabilities,
+  signTransaction: async () => '0x02f8',
+};
+
+const ethManager: EthSigningManager = {
+  ...nativeManager,
+  getEthSigner: () => ethSigner,
+};
+
+describe('EthTransactionRequest', () => {
+  test('should accept an EIP-1559 request with an SDK supplied nonce', () => {
+    const request: EthTransactionRequest = {
+      from: '0x1234567890123456789012345678901234567890',
+      to: '0x0000000000000000000000000000000000000901',
+      data: '0x0007044142',
+      value: '0x0',
+      gas: '0x5208',
+      chainId: '0x1b39',
+      nonce: '0x0',
+      maxFeePerGas: '0x3b9aca00',
+      maxPriorityFeePerGas: '0x0',
+      type: 2,
+    };
+
+    expect(request.value).toBe('0x0');
+    expect(request.type).toBe(2);
+  });
+
+  test('should accept a legacy request with no nonce, for a wallet that broadcasts', () => {
+    const request: EthTransactionRequest = {
+      from: '0x1234567890123456789012345678901234567890',
+      to: '0x0000000000000000000000000000000000000901',
+      data: '0x0007044142',
+      value: '0x0',
+      gas: '0x5208',
+      chainId: '0x1b39',
+      gasPrice: '0x3b9aca00',
+      type: 0,
+    };
+
+    expect(request.nonce).toBeUndefined();
+    expect(request.gasPrice).toBe('0x3b9aca00');
+  });
+
+  test('should not allow a transaction type the SDK never emits', () => {
+    const request: EthTransactionRequest = {
+      from: '0x1234567890123456789012345678901234567890',
+      to: '0x0000000000000000000000000000000000000901',
+      data: '0x0007044142',
+      value: '0x0',
+      gas: '0x5208',
+      chainId: '0x1b39',
+      // @ts-expect-error the SDK emits only legacy (0) and EIP-1559 (2) transactions
+      type: 1,
+    };
+
+    expect(request.type).toBe(1);
+  });
+
+  test('should not allow transaction types rejected by the runtime', () => {
+    const request: EthTransactionRequest = {
+      from: '0x1234567890123456789012345678901234567890',
+      to: '0x0000000000000000000000000000000000000901',
+      data: '0x0007044142',
+      value: '0x0',
+      gas: '0x5208',
+      chainId: '0x1b39',
+      // @ts-expect-error EIP-4844 (3) and EIP-7702 (4) are rejected by the runtime
+      type: 3,
+    };
+
+    expect(request.type).toBe(3);
+  });
+
+  test('should require 0x-prefixed hex for the addresses', () => {
+    const request: EthTransactionRequest = {
+      // @ts-expect-error an SS58 address is not an H160
+      from: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+      to: '0x0000000000000000000000000000000000000901',
+      data: '0x0007044142',
+      value: '0x0',
+      gas: '0x5208',
+      chainId: '0x1b39',
+      type: 0,
+    };
+
+    expect(request.to).toBe('0x0000000000000000000000000000000000000901');
+  });
+});
+
+describe('EthSigner', () => {
+  test('should allow a signer that only signs', () => {
+    expect(ethSigner.signTransaction).toBeDefined();
+    expect(ethSigner.sendTransaction).toBeUndefined();
+  });
+
+  test('should allow a signer that only broadcasts', () => {
+    const sender: EthSigner = {
+      capabilities: { eip1559: false },
+      sendTransaction: async () => '0xabc',
+    };
+
+    expect(sender.signTransaction).toBeUndefined();
+    expect(sender.capabilities.eip1559).toBe(false);
+  });
+
+  test('should allow a signer that supports both modes', () => {
+    const both: EthSigner = {
+      capabilities: {},
+      signTransaction: async () => '0x02f8',
+      sendTransaction: async () => '0xabc',
+    };
+
+    expect(both.signTransaction).toBeDefined();
+    expect(both.sendTransaction).toBeDefined();
+  });
+
+  test('should treat omitted eip1559 support as unspecified, i.e. defaulted by the SDK', () => {
+    const signer: EthSigner = {
+      capabilities: {},
+      signTransaction: async () => '0x02f8',
+    };
+
+    expect(signer.capabilities.eip1559).toBeUndefined();
+  });
+});
+
+describe('EthSigningManager', () => {
+  test('should implement the full SigningManager interface', async () => {
+    const manager: SigningManager = ethManager;
+
+    await expect(manager.getAccounts()).resolves.toEqual([
+      '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+    ]);
+    expect(manager.getExternalSigner()).toBe(externalSigner);
+    expect(manager.setSs58Format(12)).toBeUndefined();
+  });
+
+  test('should return an EthSigner synchronously', () => {
+    expect(ethManager.getEthSigner()).toBe(ethSigner);
+  });
+});
+
+describe('isEthSigningManager', () => {
+  test('should return true for a manager exposing getEthSigner', () => {
+    expect(isEthSigningManager(ethManager)).toBe(true);
+  });
+
+  test('should return false for a plain Signing Manager', () => {
+    expect(isEthSigningManager(nativeManager)).toBe(false);
+  });
+
+  test('should return false when getEthSigner is not callable', () => {
+    const malformed = { ...nativeManager, getEthSigner: 'nope' } as unknown as SigningManager;
+
+    expect(isEthSigningManager(malformed)).toBe(false);
+  });
+
+  test('should return false for a null or undefined manager', () => {
+    expect(isEthSigningManager(null)).toBe(false);
+    expect(isEthSigningManager(undefined)).toBe(false);
+  });
+
+  test('should narrow the type when it returns true', () => {
+    const manager: SigningManager = ethManager;
+
+    if (isEthSigningManager(manager)) {
+      expect(manager.getEthSigner().capabilities).toBe(capabilities);
+    } else {
+      throw new Error('expected the manager to be narrowed to an EthSigningManager');
+    }
+  });
+});

--- a/src/eth-signer.ts
+++ b/src/eth-signer.ts
@@ -1,0 +1,191 @@
+import { SigningManager } from './signing-manager';
+import { HexString } from './utils';
+
+/**
+ * An Ethereum transaction, ready to be signed
+ *
+ * Every field is populated by the SDK. A signer must pass the request through to the
+ * wallet/provider as given: it must not estimate gas, fetch a nonce, alter the transaction type or
+ * substitute its own destination address. Doing any of those reintroduces failure modes the SDK
+ * deliberately avoids (most notably wallet gas estimation, which produces a nonsensical fee on a
+ * chain whose block gas limit is `u64::MAX`)
+ */
+export interface EthTransactionRequest {
+  /**
+   * 0x-prefixed H160 of the signing key. This is the Ethereum address the SDK derived from the
+   * SS58 signing Account, and must be one of the addresses the manager reported through
+   * `getAccounts()`
+   */
+  from: HexString;
+  /**
+   * The runtime pallets sentinel address, supplied by the SDK. Dispatching to it is what makes the
+   * `data` payload execute as a Polymesh runtime call rather than as an EVM contract call.
+   * A signer must never derive or override this value
+   */
+  to: HexString;
+  /**
+   * The SCALE-encoded `RuntimeCall` to dispatch. This is *not* EVM calldata and cannot be ABI
+   * decoded
+   */
+  data: HexString;
+  /**
+   * Always zero. Value transfer is expressed through the encoded `RuntimeCall`, never through the
+   * Ethereum transaction
+   */
+  value: '0x0';
+  /**
+   * Gas limit, supplied by the SDK from its dry run of the call.
+   *
+   * The signer must **not** estimate gas or let the wallet estimate it
+   */
+  gas: HexString;
+  /**
+   * The chain's Ethereum chain ID, read from chain constants by the SDK.
+   *
+   * A signer **must** sign for exactly this chain ID. It must never fall back to the chain the
+   * provider happens to be connected to — an injected wallet sitting on Ethereum mainnet will
+   * otherwise produce a signature this chain rejects, or a valid signature for the wrong chain.
+   * Verify the provider's current chain (and switch, or throw) before signing
+   */
+  chainId: HexString;
+  /**
+   * Set when the SDK broadcasts, since it owns nonce sequencing there.
+   *
+   * Omitted when the wallet broadcasts, in which case the wallet owns the nonce
+   */
+  nonce?: HexString;
+  /**
+   * Set (along with `maxPriorityFeePerGas`) when the signer supports EIP-1559, producing a type 2
+   * transaction
+   */
+  maxFeePerGas?: HexString;
+  /**
+   * Set (along with `maxFeePerGas`) when the signer supports EIP-1559, producing a type 2
+   * transaction
+   */
+  maxPriorityFeePerGas?: HexString;
+  /**
+   * Set instead of the EIP-1559 fee fields when `EthSignerCapabilities.eip1559` is `false`,
+   * producing a legacy (type 0) transaction
+   */
+  gasPrice?: HexString;
+  /**
+   * Ethereum transaction type, always set by the SDK.
+   *
+   * Only legacy (0) and EIP-1559 (2) are emitted. The runtime also permits EIP-2930 (1), but the
+   * SDK has no reason to produce one — its access list means nothing on the sentinel path — so
+   * signers do not need to handle it. EIP-4844 (3) and EIP-7702 (4) are rejected by the runtime
+   * outright
+   */
+  type: 0 | 2;
+}
+
+/**
+ * Describes what an {@link EthSigner} is able to do, beyond what the presence of its methods
+ * already says.
+ *
+ * Whether a signer can sign or broadcast is expressed by implementing `signTransaction` /
+ * `sendTransaction` — not by a flag — so this covers only what cannot be derived from the object's
+ * shape
+ */
+export interface EthSignerCapabilities {
+  /**
+   * Whether the signer supports EIP-1559 (type 2) transactions. Defaults to `true` when omitted.
+   *
+   * Set it to `false` for signers that can only encode legacy (type 0) transactions, in which case
+   * the SDK populates `gasPrice` instead of the EIP-1559 fee fields.
+   *
+   * Note this is a question of encoding support, not of cost: the SDK sets
+   * `maxPriorityFeePerGas` to zero and `maxFeePerGas` to the chain's gas price, so a type 2
+   * transaction here is economically identical to the legacy equivalent
+   */
+  eip1559?: boolean;
+}
+
+/**
+ * Signs Polymesh runtime calls with an Ethereum key.
+ *
+ * At least one of `signTransaction` and `sendTransaction` **must** be implemented. The SDK decides
+ * how to submit by looking at which of them is present, so a signer that cannot sign simply does
+ * not define `signTransaction`. When both are available the SDK prefers `signTransaction`, as it
+ * lets the SDK broadcast the transaction itself and so keeps control of the nonce and of the full
+ * submission lifecycle.
+ *
+ * The SDK will not silently fall back from one mode to the other, because changing who owns the
+ * nonce mid-flight is worse than failing loudly.
+ *
+ * If the user rejects the request, throw an error carrying the
+ * [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) `code` `4001`, which the SDK
+ * maps to `TransactionRejectedByUser`. Providers already produce this code, so re-throwing the
+ * provider's error unchanged — or preserving its `code` when wrapping it — is usually enough
+ */
+export interface EthSigner {
+  /**
+   * What this signer can do beyond what its methods imply. The SDK reads this rather than probing
+   * the provider, since probing would mean sending a speculative request to the user's wallet
+   */
+  readonly capabilities: EthSignerCapabilities;
+  /**
+   * Sign the transaction and return the raw signed transaction bytes, without broadcasting.
+   *
+   * Preferred — it lets the SDK broadcast and track the transaction natively, over the existing
+   * Polymesh connection, with no Ethereum RPC endpoint involved.
+   *
+   * Leave undefined if the signer cannot sign without also broadcasting
+   */
+  signTransaction?(tx: EthTransactionRequest): Promise<HexString>;
+  /**
+   * Sign **and** broadcast the transaction, returning the Ethereum transaction hash.
+   *
+   * For wallets that do not expose a sign-only method (most injected EIP-1193 providers). The SDK
+   * correlates the returned hash back to a Polymesh extrinsic.
+   *
+   * Leave undefined if the signer cannot broadcast
+   */
+  sendTransaction?(tx: EthTransactionRequest): Promise<HexString>;
+}
+
+/**
+ * A Signing Manager that can sign Polymesh transactions with Ethereum keys.
+ *
+ * An Ethereum key dispatches a runtime call as the Account
+ * `AccountId32 = <20 byte H160> ++ [0xEE; 12]`, so an `EthSigningManager` is a normal
+ * {@link SigningManager} whose Accounts happen to be Ethereum derived. It must implement the full
+ * `SigningManager` interface:
+ *
+ * - `getAccounts()` returns the **SS58 encoded** `0xEE` Accounts, *not* H160 hex strings. The SDK
+ *   routes on the address, so returning hex would break Account resolution everywhere
+ * - `setSs58Format()` is honoured when encoding those Accounts. The SDK calls it before
+ *   `getAccounts()`, but the manager should hold a sane default (`42`) for standalone use
+ * - `getExternalSigner()` returns a `PolkadotSigner` whose `signPayload` and `signRaw`
+ *   **throw**. It is never invoked on the Ethereum path, but the type demands it, and an Ethereum
+ *   key cannot produce a valid SCALE/sr25519 signature — a loud throw is required, since a
+ *   signature the chain will silently reject is far worse
+ *
+ * A hybrid manager holding both native and Ethereum keys needs no extra API: routing is
+ * per address, and `getEthSigner()` is only consulted for Ethereum derived addresses
+ */
+export interface EthSigningManager extends SigningManager {
+  /**
+   * Return the signer that handles Ethereum signing logic.
+   *
+   * This is synchronous, matching `getExternalSigner()`. Since resolving
+   * {@link EthSignerCapabilities} may need an async round trip to the provider, an implementation
+   * should resolve them once in its own async `create()` factory and hand back a ready made signer
+   * here.
+   *
+   * It takes no address: the signer receives the address to sign for as
+   * {@link EthTransactionRequest.from}, so a single signer must handle every Ethereum derived
+   * Account the manager reports through `getAccounts()`
+   */
+  getEthSigner(): EthSigner;
+}
+
+/**
+ * Whether the given Signing Manager can sign Polymesh transactions with Ethereum keys
+ */
+export function isEthSigningManager(
+  manager: SigningManager | null | undefined
+): manager is EthSigningManager {
+  return !!manager && typeof (manager as EthSigningManager).getEthSigner === 'function';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './eth-signer';
 export * from './signing-manager';
 export * from './utils';


### PR DESCRIPTION
## Ethereum signing manager types

Adds the types a signing manager needs to sign Polymesh transactions with an Ethereum key, via the `revive` pallet's `AccountId32 = <20 byte H160> ++ [0xEE; 12]` account derivation.

Purely additive — no existing export changes. Targeting `beta` so the interface can be validated against both consumers before it reaches `latest`.

### API

- `EthSigningManager` — extends `SigningManager` with a synchronous `getEthSigner()`. The SDK routes on the signing address, so a hybrid manager may hold both native and Ethereum keys with no extra configuration.
- `EthSigner` — implements `signTransaction` and/or `sendTransaction`; at least one is required.
- `EthTransactionRequest` — the transaction the SDK builds. Every field is SDK-supplied.
- `EthSignerCapabilities` — currently just `eip1559`.
- `isEthSigningManager(manager)` — typeguard for consumers routing between the native and Ethereum paths.

### Design notes

These came out of implementing the SDK side first, which surfaced a few things worth fixing before the interface is published:

- **Submission mode is derived from which methods a signer implements**, not from capability booleans. Booleans sitting beside optional methods of the same name can contradict them, and the consumer pays for that in non-null assertions and defensive guards for cases the type system should make unrepresentable.
- **`EthSignerCapabilities` carries only what the shape cannot express** — `eip1559`, optional and defaulting to `true`, so a signer declares it only when it *cannot* encode a type 2 transaction.
- **`chainId` is a MUST, not a hint.** A signer has to sign for the chain in the request and never fall back to whichever chain its provider happens to be connected to — an injected wallet sitting on Ethereum mainnet otherwise produces a signature this chain rejects, or a valid signature for the wrong chain.
- **Rejection is specified as EIP-1193 `code` `4001`** rather than a message substring, so a signer that re-throws its provider's error unchanged is understood without having to format its message to suit the SDK.
- **`type` is narrowed to `0 | 2`**, the only transaction types the SDK emits. The runtime also permits EIP-2930 (1), but its access list means nothing on the sentinel path, so signers need not handle it.

### Downstream

Both consumers currently carry local mirrors of these interfaces marked `TODO: replace with import ... once >=3.8.0 is published`, and neither can drop them until this is released:

- `polymesh-sdk` — Ethereum signing support (unreleased)
- `eth-signing-manager` — new package, not yet published

### Testing

`yarn lint`, `yarn test` and `tsc --noEmit` all pass; `eth-signer.ts` is at 100% coverage. Note that the interface has not yet been exercised against a live chain or a real wallet — that validation is the reason for going out on `beta` first.
